### PR TITLE
Add dry-run workflow, Godot packaging & publish, version bumps, docs

### DIFF
--- a/.github/workflows/dry-run-pack.yml
+++ b/.github/workflows/dry-run-pack.yml
@@ -1,0 +1,43 @@
+name: Dry Run Package Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build Core
+        run: dotnet build StateMachineKit.Core/StateMachineKit.Core.csproj -c Release --no-restore
+
+      - name: Pack Core (no publish)
+        run: dotnet pack StateMachineKit.Core/StateMachineKit.Core.csproj -c Release --no-build -o ./artifacts/core
+
+      - name: Build Godot
+        run: dotnet build StateMachineKit.Godot/StateMachineKit.Godot.csproj -c Release --no-restore
+
+      - name: Pack Godot (no publish)
+        run: dotnet pack StateMachineKit.Godot/StateMachineKit.Godot.csproj -c Release --no-build -o ./artifacts/godot
+
+      - name: Upload Core nupkg
+        uses: actions/upload-artifact@v4
+        with:
+          name: core-nuget
+          path: artifacts/core/*.nupkg
+
+      - name: Upload Godot nupkg
+        uses: actions/upload-artifact@v4
+        with:
+          name: godot-nuget
+          path: artifacts/godot/*.nupkg

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,4 +1,4 @@
-name: Publish Core package
+name: Publish Packages
 
 on:
   push:
@@ -21,11 +21,20 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
-      - name: Build (exclude tests)
+      - name: Build Core
         run: dotnet build StateMachineKit.Core/StateMachineKit.Core.csproj --configuration Release --no-restore
 
-      - name: Pack (core project only)
-        run: dotnet pack StateMachineKit.Core/StateMachineKit.Core.csproj --configuration Release --no-build --output ./nupkg
+      - name: Pack Core
+        run: dotnet pack StateMachineKit.Core/StateMachineKit.Core.csproj --configuration Release --no-build --output ./nupkg/core
 
-      - name: Publish to NuGet.org
-        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      - name: Build Godot
+        run: dotnet build StateMachineKit.Godot/StateMachineKit.Godot.csproj --configuration Release --no-restore
+
+      - name: Pack Godot
+        run: dotnet pack StateMachineKit.Godot/StateMachineKit.Godot.csproj --configuration Release --no-build --output ./nupkg/godot
+
+      - name: Publish Core to NuGet.org
+        run: dotnet nuget push ./nupkg/core/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Publish Godot to NuGet.org
+        run: dotnet nuget push ./nupkg/godot/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# StateMachineKit
+
+StateMachineKit is a flexible, plug-and-play finite state machine (FSM) toolkit for .NET / game development.
+It provides a lightweight abstraction for defining states, transitioning between them, and integrating with engines
+(such as Godot via the companion `StateMachineKit.Godot` package).
+
+## Packages
+
+| Package | Version | Description |
+|---------|---------|-------------|
+| StateMachineKit | 2.0.0 | Core abstractions (interfaces, discovery attribute, helpers) supporting .NET 8 and .NET Standard 2.1. |
+| StateMachineKit.Godot | 0.0.1 | Godot (C#) integration layer depending on the core package. |
+
+## Key Features
+- Generic, owner-driven state machine: `IStateMachine<TContext>` / `IState<TContext>`
+- Attribute-based automatic state discovery (`[DiscoverableState]`)
+- Extension methods for ticking (Update / FixedUpdate)
+- Pluggable design; you keep your concrete state definitions decoupled
+- Godot integration package for engine-specific hooks
+
+## Quick Start (Core)
+```csharp
+public sealed class IdleState : IState<MyActor> { /* ... */ }
+public sealed class MoveState : IState<MyActor> { /* ... */ }
+
+var actor = new MyActor("Player");
+var fsm = FiniteStateMachine.Create(actor);
+fsm.Initialize<IdleState>();
+
+// In your update loop
+fsm.Tick(deltaTime);
+```
+
+## Godot Integration
+Install the `StateMachineKit.Godot` NuGet package and reference it from your Godot C# project. The Godot layer
+adds engine-friendly owner definitions and can be extended to tie into lifecycle callbacks (`_Process`, `_PhysicsProcess`).
+
+## Versioning
+- Core at 2.0.0 introduces improved initialization semantics and packaging metadata
+- Godot integration starts at 0.0.1 (early preview)
+
+## Roadmap
+- Source generator for compile-time state registration
+- Transition validation & visualization hooks
+- Async lifecycle (optional)
+
+## Contributing
+Issues and PRs are welcome. Please include tests for behavioral changes.
+
+## License
+MIT – see `license.md`.

--- a/StateMachineKit.Core/StateMachineKit.Core.csproj
+++ b/StateMachineKit.Core/StateMachineKit.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net8.0; netstandard2.1</TargetFrameworks>
@@ -8,8 +8,19 @@
         
         <Author>Christos Maragkos</Author>
         <PackageId>StateMachineKit</PackageId>
+        <Version>2.0.0</Version>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Description>StateMachineKit is a library for creating and managing finite state machines within a game.</Description>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageLicenseFile>license.md</PackageLicenseFile>
+        <RepositoryUrl>https://github.com/ChristosMaragkos/StateMachineKit</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageTags>state-machine;fsm;game-dev;ai</PackageTags>
     </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\README.md" Pack="true" PackagePath="/" Link="README.md" />
+        <None Include="..\license.md" Pack="true" PackagePath="/" Link="license.md" />
+    </ItemGroup>
 
 </Project>

--- a/StateMachineKit.Godot/StateMachineKit.Godot.csproj
+++ b/StateMachineKit.Godot/StateMachineKit.Godot.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Godot.NET.Sdk/4.4.1">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <EnableDynamicLoading>true</EnableDynamicLoading>
+        <Nullable>enable</Nullable>
+        <PackageId>StateMachineKit.Godot</PackageId>
+        <Version>0.0.1</Version>
+        <Description>Godot integration layer for StateMachineKit finite state machine library.</Description>
+        <Authors>Christos Maragkos</Authors>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageLicenseFile>license.md</PackageLicenseFile>
+        <RepositoryUrl>https://github.com/ChristosMaragkos/StateMachineKit</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageTags>godot;state-machine;fsm;game-dev;ai</PackageTags>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\StateMachineKit.Core\StateMachineKit.Core.csproj" />
+      <None Include="..\README.md" Pack="true" PackagePath="/" Link="README.md" />
+      <None Include="..\license.md" Pack="true" PackagePath="/" Link="license.md" />
+    </ItemGroup>
+
+</Project>

--- a/license.md
+++ b/license.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Christos Maragkos
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
This PR adds a dry-run packaging workflow, updates the publish workflow to include both the Core and Godot packages, bumps package versions, and introduces README + MIT license for NuGet packaging.

## Changes
- Core package version bumped to **2.0.0** with added NuGet metadata (README, license, repo URL, tags).
- Godot integration package introduced as **0.0.1** with independent packaging metadata and dependency on Core.
- Added `dry-run-pack.yml` workflow (manual dispatch) that builds and packs Core & Godot without publishing, uploading artifacts.
- Updated `publish-package.yml` to build, pack, and publish Core and Godot packages separately on tag push (`v*`).
- Added `README.md` and `license.md` and included them in both packages.
- Resolved Godot duplicate attribute build errors by disabling assembly info and target framework attribute generation in the Godot `.csproj`.

## Workflows
### Dry Run (`dry-run-pack.yml`)
Trigger via workflow dispatch. Produces artifacts:
- `core-nuget` → Core `.nupkg`
- `godot-nuget` → Godot `.nupkg`

### Publish (`publish-package.yml`)
Triggered on tag push (`v*`). Publishes both packages independently (not bundled) while preserving dependency of `StateMachineKit.Godot` on `StateMachineKit`.

## Rationale
Separating Core and Godot packaging keeps the Godot layer optional and small while preserving clear versioning. The dry-run workflow allows verification before tagging/publishing.

## Next Steps (optional follow-ups)
- Add CI test execution before packing.
- Introduce semantic-release style automated versioning.
- Add source generator or registration API for states (transition map validation).

## Checklist
- [x] Core builds & packs locally
- [x] Godot builds & packs locally (duplicate attribute issue fixed)
- [x] README and license included in packages
- [x] Separate workflows for dry run & publish

Let me know if you'd like the PR split or further adjustments.
